### PR TITLE
Test expanding fake classes via basic inheritance

### DIFF
--- a/spec/json-fakefield_spec.cr
+++ b/spec/json-fakefield_spec.cr
@@ -164,8 +164,7 @@ Spectator.describe JSON::FakeField do
     # The use of typecasting "as(Sum)", allows us to explore if we slice
     # classes.  Since Crystal Classes are referenced based, this should not
     # be a problem, but I'd like confirmation
-    sample [UniversalAnswer.new(10_u32, 5_u32), UniversalAnswer.new(10_u32, 5_u32).as(Sum) ] do |subj|
-
+    sample [UniversalAnswer.new(10_u32, 5_u32), UniversalAnswer.new(10_u32, 5_u32).as(Sum)] do |subj|
       it "supports overriding fake functions" do
         expect(subj.to_json).to eq(%q({"a":10,"b":5,"universal_constant":42,"sum":42}))
         # verify that a function in our base class "Sum::result" calls the
@@ -179,6 +178,5 @@ Spectator.describe JSON::FakeField do
         expect(result["b"]).to eq(b)
       end
     end
-
   end
 end


### PR DESCRIPTION
So actually the original code "just works".  However, including multiple:

```
      include JSON::Serializable                                               
      include JSON::Serializable::Fake # This **MUST** be last     
```

...in your class inheritance **will** break things.  **But** if this only appears once (in your base class) - everything works as expected.